### PR TITLE
Default to authenticated user if no user is passed as parameter

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -38,8 +38,11 @@ class Provider
      *
      * @return \Orchestra\Avatar\HandlerInterface
      */
-    public function user($user)
+    public function user($user = null)
     {
+        if (empty($user)) {
+            $user = auth()->user();
+        }
         return $this->handler->setIdentifierFromUser($user);
     }
 


### PR DESCRIPTION
It's a really little improvement to the usage, but I consider it useful... I just wanted to get the avatar of the authenticated user without having to specify each time
